### PR TITLE
feat(DeMIMA UI Viewer): exception throwing changed with a javax swing

### DIFF
--- a/DeMIMA UI Viewer/src/main/java/ptidej/viewer/ViewerCommons.java
+++ b/DeMIMA UI Viewer/src/main/java/ptidej/viewer/ViewerCommons.java
@@ -108,9 +108,20 @@ public class ViewerCommons {
 									.errorOutput());
 							}
 							catch (final InvocationTargetException ite) {
-								ite.printStackTrace(ProxyConsole
-									.getInstance()
-									.errorOutput());
+							    if (ite.getCause() != null && ite.getCause().getClass().getSimpleName()
+							            .equals("UnsupportedSourceModelException")) {
+							        javax.swing.JOptionPane.showMessageDialog(
+							            null,
+							            "The current model does not support AAC Relationships analysis.\n"
+							            + "Please load a Java bytecode or source code model first.",
+							            "Unsupported Model Type",
+							            javax.swing.JOptionPane.WARNING_MESSAGE);
+							    }
+							    else {
+							        ite.printStackTrace(ProxyConsole
+							            .getInstance()
+							            .errorOutput());
+							    }
 							}
 						}
 					};


### PR DESCRIPTION
dialog box.


Caused by: padl.analysis.UnsupportedSourceModelException
    at padl.analysis.repository.AACRelationshipsAnalysis.invoke(AACRelationshipsAnalysis.java:72)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    ... 29 more

The above exception changed with the following:

<img width="505" height="159" alt="image" src="https://github.com/user-attachments/assets/3fdbe3a0-aaf7-443b-a269-00e3c9567d99" />
