### PR TITLE
Fix Issue #412: decouple IDependencyIndependentMetric from IUnaryMetric

### DIFF
--- a/POM/src/main/java/pom/metrics/IDependencyIndependentMetric.java
+++ b/POM/src/main/java/pom/metrics/IDependencyIndependentMetric.java
@@ -12,6 +12,7 @@ package pom.metrics;
 
 // Tagging interface for model independent metrics (like LCOM...)
 // TODO It could be more interesting to have IUnary (truly), IBinary, and INary metrics.
-public interface IDependencyIndependentMetric extends IUnaryMetric {
+public interface IDependencyIndependentMetric extends IMetric {
+	
 
 }


### PR DESCRIPTION
This PR addresses Issue #412 by decoupling IDependencyIndependentMetric
from IUnaryMetric.

Change:
- IDependencyIndependentMetric now extends IMetric instead of
  IUnaryMetric.

Validation:
- Maven compile: BUILD SUCCESS
- UnaryCBOTest: 4 tests, 0 failures, 0 errors
- CacheTest: 5 tests, 0 failures, 0 errors

Note:
- DITTest still fails with the same Java source-level / pattern-matching
  error on an untouched upstream/master baseline, so that failure is not
  introduced by this change.

Closes #412